### PR TITLE
Fix data flow

### DIFF
--- a/app/src/main/java/hu/bme/aut/fitary/dataSource/FirebaseDataSource.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/dataSource/FirebaseDataSource.kt
@@ -7,12 +7,8 @@ import hu.bme.aut.fitary.dataSource.model.Workout
 import hu.bme.aut.fitary.domainModel.DomainExercise
 import hu.bme.aut.fitary.domainModel.DomainUser
 import hu.bme.aut.fitary.domainModel.DomainWorkout
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.shareIn
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -27,10 +23,10 @@ class FirebaseDataSource @Inject constructor(
     private val workoutDAO: WorkoutDAO
 ) {
 
-    var workoutsFlow: SharedFlow<List<DomainWorkout>> = workoutDAO.workoutsFlow.map {
+    var workoutsFlow: Flow<List<DomainWorkout>> = workoutDAO.workoutsFlow.map {
         it.map { workout ->
-
             var score = 0.0
+
             for (i in 0 until workout.exercises.size) {
                 val scorePerRep = exerciseDAO.getExerciseScoreById(workout.exercises[i]) ?: 0.0
                 score += scorePerRep * workout.reps[i]
@@ -44,11 +40,7 @@ class FirebaseDataSource @Inject constructor(
                 comment = workout.comment
             )
         }
-    }.shareIn(
-        scope = CoroutineScope(Dispatchers.Default),
-        started = SharingStarted.Eagerly,
-        replay = 1
-    )
+    }
 
     // TODO Improve mapping code style
     //  docs: https://rainbowcake.dev/best-practices/mapping-code-style/

--- a/app/src/main/java/hu/bme/aut/fitary/dataSource/FirebaseDataSource.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/dataSource/FirebaseDataSource.kt
@@ -1,5 +1,6 @@
 package hu.bme.aut.fitary.dataSource
 
+import android.util.Log
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
 import com.google.android.gms.tasks.OnFailureListener
@@ -75,6 +76,8 @@ class FirebaseDataSource @Inject constructor(
 
         userDAO.saveUser(newUser)
     }
+
+    suspend fun getCurrentUserId() = userDAO.getCurrentUserId()
 
     suspend fun getCurrentUser(): DomainUser? {
         return userDAO.currentUser?.let { userProfile ->

--- a/app/src/main/java/hu/bme/aut/fitary/dataSource/FirebaseDataSource.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/dataSource/FirebaseDataSource.kt
@@ -1,7 +1,5 @@
 package hu.bme.aut.fitary.dataSource
 
-import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.Observer
 import com.google.android.gms.tasks.OnFailureListener
 import com.google.android.gms.tasks.OnSuccessListener
 import hu.bme.aut.fitary.dataSource.model.UserProfile
@@ -18,9 +16,9 @@ import kotlinx.coroutines.flow.shareIn
 import javax.inject.Inject
 import javax.inject.Singleton
 
-/* Responsibilities:
-    Mapping from data models to domain models
-    Providing access to CRUD operations
+/** Responsibilities:
+ * Mapping from data models to domain models;
+ * Providing access to CRUD operations.
  */
 @Singleton
 class FirebaseDataSource @Inject constructor(
@@ -51,30 +49,6 @@ class FirebaseDataSource @Inject constructor(
         started = SharingStarted.Eagerly,
         replay = 1
     )
-
-    val workouts = MutableLiveData<MutableList<DomainWorkout>>()
-    private val workoutObserver = Observer<MutableList<Workout>> {
-        workouts.value = it.map { workout ->
-
-            var score = 0.0
-            for (i in 0 until workout.exercises.size) {
-                val scorePerRep = exerciseDAO.getExerciseScoreById(workout.exercises[i]) ?: 0.0
-                score += scorePerRep * workout.reps[i]
-            }
-
-            DomainWorkout(
-                uid = workout.uid ?: "Unknown user",
-                username = userDAO.users[workout.uid]?.username ?: "No username",
-                domainExercises = mapWorkoutExercisesToDomain(workout),
-                score = score,
-                comment = workout.comment
-            )
-        }.toMutableList()
-    }
-
-    init {
-        workoutDAO.workouts.observeForever(workoutObserver)
-    }
 
     // TODO Improve mapping code style
     //  docs: https://rainbowcake.dev/best-practices/mapping-code-style/

--- a/app/src/main/java/hu/bme/aut/fitary/dataSource/UserDAO.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/dataSource/UserDAO.kt
@@ -1,5 +1,7 @@
 package hu.bme.aut.fitary.dataSource
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.database.ChildEventListener
 import com.google.firebase.database.DataSnapshot
@@ -33,6 +35,7 @@ class UserDAO @Inject constructor() {
                     newUser?.let { _users += Pair(it.id, it) }
                 }
 
+                @RequiresApi(Build.VERSION_CODES.N)
                 override fun onChildChanged(
                     dataSnapshot: DataSnapshot,
                     previousChildName: String?
@@ -55,6 +58,8 @@ class UserDAO @Inject constructor() {
                 }
             })
     }
+
+    suspend fun getCurrentUserId() = auth.currentUser?.uid
 
     suspend fun saveUser(user: UserProfile) {
         if (_users.containsKey(user.id) && _users[user.id] == user)

--- a/app/src/main/java/hu/bme/aut/fitary/dataSource/WorkoutDAO.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/dataSource/WorkoutDAO.kt
@@ -9,8 +9,7 @@ import com.google.firebase.database.FirebaseDatabase
 import hu.bme.aut.fitary.dataSource.model.Workout
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
@@ -23,10 +22,7 @@ class WorkoutDAO @Inject constructor() {
 
     private val workoutMap = mutableMapOf<String?, Workout>()
 
-    val workoutsFlow = MutableSharedFlow<List<Workout>>(
-        replay = 1,
-        onBufferOverflow = BufferOverflow.DROP_OLDEST
-    )
+    val workoutsFlow = MutableStateFlow<List<Workout>>(listOf())
 
     init {
         database

--- a/app/src/main/java/hu/bme/aut/fitary/interactor/UserInteractor.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/interactor/UserInteractor.kt
@@ -10,6 +10,9 @@ import javax.inject.Singleton
 class UserInteractor @Inject constructor(
     private val firebaseDataSource: FirebaseDataSource
 ) {
+
+    suspend fun getCurrentUser() = firebaseDataSource.getCurrentUser()
+
     suspend fun getUsernameById(userId: String): String? =
         firebaseDataSource.getUserById(userId)?.username
 
@@ -22,7 +25,5 @@ class UserInteractor @Inject constructor(
             )
         )
     }
-
-    suspend fun getCurrentUser() = firebaseDataSource.getCurrentUser()
 
 }

--- a/app/src/main/java/hu/bme/aut/fitary/interactor/WorkoutInteractor.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/interactor/WorkoutInteractor.kt
@@ -1,6 +1,5 @@
 package hu.bme.aut.fitary.interactor
 
-import androidx.lifecycle.MutableLiveData
 import com.google.android.gms.tasks.OnFailureListener
 import com.google.android.gms.tasks.OnSuccessListener
 import hu.bme.aut.fitary.dataSource.FirebaseDataSource
@@ -16,14 +15,12 @@ import javax.inject.Singleton
 @Singleton
 class WorkoutInteractor @Inject constructor(
     private val firebaseDataSource: FirebaseDataSource
-) : Observable<MutableList<DomainWorkout>> {
+) {
 
     private var currentUserId: String? = null
 
-    override val observers = mutableListOf<Observer<MutableList<DomainWorkout>>>()
-
     val allWorkoutsFlow = firebaseDataSource.workoutsFlow.shareIn(
-        scope = CoroutineScope(Dispatchers.Default),
+        scope = CoroutineScope(Dispatchers.IO),
         started = SharingStarted.Eagerly,
         replay = 1
     )
@@ -36,25 +33,10 @@ class WorkoutInteractor @Inject constructor(
             it.uid == currentUserId
         }
     }.shareIn(
-        scope = CoroutineScope(Dispatchers.Default),
+        scope = CoroutineScope(Dispatchers.IO),
         started = SharingStarted.Eagerly,
         replay = 1
     )
-
-
-    val userWorkoutsLiveData = MutableLiveData<MutableList<DomainWorkout>>()
-
-    init {
-
-        firebaseDataSource.workouts.observeForever { observedWorkouts ->
-            if (currentUserId != null) {
-                userWorkoutsLiveData.value = observedWorkouts.filter {
-                    it.uid == currentUserId
-                }.toMutableList()
-            }
-        }
-
-    }
 
     suspend fun saveWorkout(
         workout: DomainWorkout,

--- a/app/src/main/java/hu/bme/aut/fitary/interactor/WorkoutInteractor.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/interactor/WorkoutInteractor.kt
@@ -10,8 +10,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.shareIn
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -47,11 +45,6 @@ class WorkoutInteractor @Inject constructor(
     val userWorkoutsLiveData = MutableLiveData<MutableList<DomainWorkout>>()
 
     init {
-        runBlocking {
-            launch {
-                currentUserId = firebaseDataSource.getCurrentUserId()
-            }
-        }
 
         firebaseDataSource.workouts.observeForever { observedWorkouts ->
             if (currentUserId != null) {

--- a/app/src/main/java/hu/bme/aut/fitary/ui/charts/pieChart/PieChartFragment.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/charts/pieChart/PieChartFragment.kt
@@ -32,12 +32,6 @@ class PieChartFragment : RainbowCakeFragment<PieChartViewState, PieChartViewMode
         }
     }
 
-    override fun onDestroy() {
-        viewModel.cancelFlowCollection()
-
-        super.onDestroy()
-    }
-
     override fun render(viewState: PieChartViewState) {
         when (viewState) {
             is Loading -> {

--- a/app/src/main/java/hu/bme/aut/fitary/ui/charts/pieChart/PieChartFragment.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/charts/pieChart/PieChartFragment.kt
@@ -13,6 +13,9 @@ import kotlinx.android.synthetic.main.fragment_chart_pie.*
 
 class PieChartFragment : RainbowCakeFragment<PieChartViewState, PieChartViewModel>() {
 
+    // TODO ViewModel is not bound to Activity scope!
+    //  It will get destroyed upon Fragment destruction!
+    //  Bind it to MainActivity or cancel flow collection on destruction
     override fun provideViewModel() = getViewModelFromFactory()
     override fun getViewResource() = R.layout.fragment_chart_pie
 

--- a/app/src/main/java/hu/bme/aut/fitary/ui/charts/pieChart/PieChartFragment.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/charts/pieChart/PieChartFragment.kt
@@ -13,9 +13,6 @@ import kotlinx.android.synthetic.main.fragment_chart_pie.*
 
 class PieChartFragment : RainbowCakeFragment<PieChartViewState, PieChartViewModel>() {
 
-    // TODO ViewModel is not bound to Activity scope!
-    //  It will get destroyed upon Fragment destruction!
-    //  Bind it to MainActivity or cancel flow collection on destruction
     override fun provideViewModel() = getViewModelFromFactory()
     override fun getViewResource() = R.layout.fragment_chart_pie
 
@@ -33,6 +30,12 @@ class PieChartFragment : RainbowCakeFragment<PieChartViewState, PieChartViewMode
             extraLeftOffset = 30f
             extraRightOffset = 30f
         }
+    }
+
+    override fun onDestroy() {
+        viewModel.cancelFlowCollection()
+
+        super.onDestroy()
     }
 
     override fun render(viewState: PieChartViewState) {

--- a/app/src/main/java/hu/bme/aut/fitary/ui/charts/pieChart/PieChartFragment.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/charts/pieChart/PieChartFragment.kt
@@ -30,14 +30,6 @@ class PieChartFragment : RainbowCakeFragment<PieChartViewState, PieChartViewMode
             extraLeftOffset = 30f
             extraRightOffset = 30f
         }
-
-        viewModel.connectView()
-    }
-
-    override fun onStop() {
-        viewModel.disconnectView()
-
-        super.onStop()
     }
 
     override fun render(viewState: PieChartViewState) {

--- a/app/src/main/java/hu/bme/aut/fitary/ui/charts/pieChart/PieChartFragment.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/charts/pieChart/PieChartFragment.kt
@@ -29,7 +29,7 @@ class PieChartFragment : RainbowCakeFragment<PieChartViewState, PieChartViewMode
 
             setDrawEntryLabels(true)
             setEntryLabelColor(Color.BLACK)
-            
+
             extraLeftOffset = 30f
             extraRightOffset = 30f
         }
@@ -38,9 +38,15 @@ class PieChartFragment : RainbowCakeFragment<PieChartViewState, PieChartViewMode
     override fun render(viewState: PieChartViewState) {
         when (viewState) {
             is Loading -> {
-                // TODO
+                // TODO Display loading indication
             }
-            is ExercisesLoaded -> renderPieChart(viewState.exercises)
+            is ExercisesLoaded -> {
+                if (viewState.exercises.isNotEmpty()) {
+                    renderPieChart(viewState.exercises)
+                } else {
+                    // TODO Display loading indication
+                }
+            }
         }.exhaustive
     }
 

--- a/app/src/main/java/hu/bme/aut/fitary/ui/charts/pieChart/PieChartPresenter.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/charts/pieChart/PieChartPresenter.kt
@@ -9,10 +9,10 @@ class PieChartPresenter @Inject constructor(
     private val workoutInteractor: WorkoutInteractor,
 ) {
 
-    val exercises : Flow<List<Exercise>> = workoutInteractor.userWorkoutsFlow.map { collectedWorkouts ->
+    val exercises: Flow<List<Exercise>> = workoutInteractor.userWorkoutsFlow.map {
         val exerciseMap = mutableMapOf<String, Double>()
 
-        collectedWorkouts.forEach { domainWorkout ->
+        it.forEach { domainWorkout ->
             domainWorkout.domainExercises.forEach { domainExercise ->
 
                 val currentScore: Double? = exerciseMap[domainExercise.name]
@@ -25,10 +25,10 @@ class PieChartPresenter @Inject constructor(
             }
         }
 
-        exerciseMap.map {
+        exerciseMap.map { pair ->
             Exercise(
-                name = it.key,
-                sumOfScore = it.value
+                name = pair.key,
+                sumOfScore = pair.value
             )
         }
     }

--- a/app/src/main/java/hu/bme/aut/fitary/ui/charts/pieChart/PieChartPresenter.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/charts/pieChart/PieChartPresenter.kt
@@ -1,46 +1,35 @@
 package hu.bme.aut.fitary.ui.charts.pieChart
 
-import androidx.lifecycle.MutableLiveData
-import hu.bme.aut.fitary.domainModel.DomainWorkout
-import hu.bme.aut.fitary.interactor.Observer
 import hu.bme.aut.fitary.interactor.WorkoutInteractor
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class PieChartPresenter @Inject constructor(
     private val workoutInteractor: WorkoutInteractor,
 ) {
 
-    val exercises = MutableLiveData<List<Exercise>>()
+    val exercises : Flow<List<Exercise>> = workoutInteractor.userWorkoutsFlow.map { collectedWorkouts ->
+        val exerciseMap = mutableMapOf<String, Double>()
 
-    init {
-        workoutInteractor.userWorkoutsLiveData.observeForever { observedWorkouts ->
-            val exerciseMap = mutableMapOf<String, Double>()
+        collectedWorkouts.forEach { domainWorkout ->
+            domainWorkout.domainExercises.forEach { domainExercise ->
 
-            observedWorkouts.forEach { domainWorkout ->
-                domainWorkout.domainExercises.forEach { domainExercise ->
+                val currentScore: Double? = exerciseMap[domainExercise.name]
 
-                    val currentScore: Double? = exerciseMap[domainExercise.name]
-
-                    if (currentScore == null) {
-                        exerciseMap += Pair(domainExercise.name, domainExercise.score)
-                    } else {
-                        exerciseMap[domainExercise.name] = currentScore + domainExercise.score
-                    }
+                if (currentScore == null) {
+                    exerciseMap += Pair(domainExercise.name, domainExercise.score)
+                } else {
+                    exerciseMap[domainExercise.name] = currentScore + domainExercise.score
                 }
             }
+        }
 
-            val mappedExercises = exerciseMap.map {
-                Exercise(
-                    name = it.key,
-                    sumOfScore = it.value
-                )
-            }
-
-            exercises.value = mappedExercises
+        exerciseMap.map {
+            Exercise(
+                name = it.key,
+                sumOfScore = it.value
+            )
         }
     }
 

--- a/app/src/main/java/hu/bme/aut/fitary/ui/charts/pieChart/PieChartViewModel.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/charts/pieChart/PieChartViewModel.kt
@@ -1,7 +1,6 @@
 package hu.bme.aut.fitary.ui.charts.pieChart
 
 import co.zsmb.rainbowcake.base.RainbowCakeViewModel
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collect
 import javax.inject.Inject
 
@@ -9,14 +8,12 @@ class PieChartViewModel @Inject constructor(
     private val presenter: PieChartPresenter
 ) : RainbowCakeViewModel<PieChartViewState>(Loading) {
 
-    private val flowCollection: Job = executeCancellable(blocking = false) {
-        presenter.exercises.collect {
-            viewState = ExercisesLoaded(it)
+    init {
+        executeNonBlocking {
+            presenter.exercises.collect {
+                viewState = ExercisesLoaded(it)
+            }
         }
-    }
-
-    fun cancelFlowCollection() {
-        flowCollection.cancel()
     }
 
 }

--- a/app/src/main/java/hu/bme/aut/fitary/ui/charts/pieChart/PieChartViewModel.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/charts/pieChart/PieChartViewModel.kt
@@ -1,6 +1,7 @@
 package hu.bme.aut.fitary.ui.charts.pieChart
 
 import co.zsmb.rainbowcake.base.RainbowCakeViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collect
 import javax.inject.Inject
 
@@ -8,12 +9,14 @@ class PieChartViewModel @Inject constructor(
     private val presenter: PieChartPresenter
 ) : RainbowCakeViewModel<PieChartViewState>(Loading) {
 
-    init {
-        executeNonBlocking {
-            presenter.exercises.collect {
-                viewState = ExercisesLoaded(it)
-            }
+    private val flowCollection: Job = executeCancellable(blocking = false) {
+        presenter.exercises.collect {
+            viewState = ExercisesLoaded(it)
         }
+    }
+
+    fun cancelFlowCollection() {
+        flowCollection.cancel()
     }
 
 }

--- a/app/src/main/java/hu/bme/aut/fitary/ui/charts/pieChart/PieChartViewModel.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/charts/pieChart/PieChartViewModel.kt
@@ -1,23 +1,16 @@
 package hu.bme.aut.fitary.ui.charts.pieChart
 
 import co.zsmb.rainbowcake.base.RainbowCakeViewModel
-import kotlinx.coroutines.channels.consumeEach
 import javax.inject.Inject
 
 class PieChartViewModel @Inject constructor(
     private val presenter: PieChartPresenter
 ) : RainbowCakeViewModel<PieChartViewState>(Loading) {
 
-    fun connectView() {
-        presenter.connectView()
-
-        execute {
-            presenter.exercisesChannel.consumeEach {
-                viewState = ExercisesLoaded(it)
-            }
+    init {
+        presenter.exercises.observeForever {
+            viewState = ExercisesLoaded(it)
         }
     }
-
-    fun disconnectView() = presenter.disconnectView()
 
 }

--- a/app/src/main/java/hu/bme/aut/fitary/ui/charts/pieChart/PieChartViewModel.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/charts/pieChart/PieChartViewModel.kt
@@ -1,6 +1,7 @@
 package hu.bme.aut.fitary.ui.charts.pieChart
 
 import co.zsmb.rainbowcake.base.RainbowCakeViewModel
+import kotlinx.coroutines.flow.collect
 import javax.inject.Inject
 
 class PieChartViewModel @Inject constructor(
@@ -8,8 +9,10 @@ class PieChartViewModel @Inject constructor(
 ) : RainbowCakeViewModel<PieChartViewState>(Loading) {
 
     init {
-        presenter.exercises.observeForever {
-            viewState = ExercisesLoaded(it)
+        executeNonBlocking {
+            presenter.exercises.collect {
+                viewState = ExercisesLoaded(it)
+            }
         }
     }
 

--- a/app/src/main/java/hu/bme/aut/fitary/ui/createWorkout/CreateWorkoutPresenter.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/createWorkout/CreateWorkoutPresenter.kt
@@ -31,7 +31,7 @@ class CreateWorkoutPresenter @Inject constructor(
         comment: String?,
         onSuccessListener: OnSuccessListener<Void>,
         onFailureListener: OnFailureListener
-    ) {
+    ) = withIOContext {
 
         val currentUser = userInteractor.getCurrentUser()
         var workoutScore = BigDecimal(0)

--- a/app/src/main/java/hu/bme/aut/fitary/ui/createWorkout/CreateWorkoutViewModel.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/createWorkout/CreateWorkoutViewModel.kt
@@ -8,7 +8,7 @@ import hu.bme.aut.fitary.ui.createWorkout.dialog.*
 import javax.inject.Inject
 
 class CreateWorkoutViewModel @Inject constructor(
-    private val createWorkoutPresenter: CreateWorkoutPresenter
+    private val presenter: CreateWorkoutPresenter
 ) : RainbowCakeViewModel<CreateWorkoutViewState>(Loading),
     ResultHandler, OnSuccessListener<Void>, OnFailureListener {
 
@@ -36,8 +36,8 @@ class CreateWorkoutViewModel @Inject constructor(
     }
 
     fun createAddExerciseDialog() = execute {
-        val exerciseNames = createWorkoutPresenter.getExerciseNames()
-        val exerciseScores = createWorkoutPresenter.getExerciseScores()
+        val exerciseNames = presenter.getExerciseNames()
+        val exerciseScores = presenter.getExerciseScores()
 
         val dialog = AddExerciseDialog(exerciseNames, exerciseScores)
         dialog.setResultHandler(this)
@@ -71,7 +71,7 @@ class CreateWorkoutViewModel @Inject constructor(
     fun saveWorkout() = execute {
         viewState = SavingWorkout
 
-        createWorkoutPresenter.saveWorkout(exercises, comment, this, this)
+        presenter.saveWorkout(exercises, comment, this, this)
     }
 
     override fun onSuccess(void: Void?) {

--- a/app/src/main/java/hu/bme/aut/fitary/ui/socialWorkouts/SocialWorkoutsFragment.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/socialWorkouts/SocialWorkoutsFragment.kt
@@ -19,12 +19,6 @@ class SocialWorkoutsFragment :
     override fun provideViewModel() = getViewModelFromFactory(scope = ViewModelScope.Activity)
     override fun getViewResource() = R.layout.fragment_workouts_social
 
-    override fun onStart() {
-        super.onStart()
-
-        viewModel.loadWorkouts()
-    }
-
     override fun render(viewState: SocialWorkoutsViewState) {
         when (viewState) {
             is Loading -> {

--- a/app/src/main/java/hu/bme/aut/fitary/ui/socialWorkouts/SocialWorkoutsFragment.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/socialWorkouts/SocialWorkoutsFragment.kt
@@ -25,9 +25,15 @@ class SocialWorkoutsFragment :
                 pbListLoading.visibility = View.VISIBLE
             }
             is SocialWorkoutsLoaded -> {
-                pbListLoading.visibility = View.GONE
-                workoutAdapter.submitList(viewState.workouts)
-                rvSocialWorkouts.smoothScrollToPosition(workoutAdapter.itemCount - 1)
+                if (viewState.workouts.isNotEmpty()) {
+                    pbListLoading.visibility = View.GONE
+                    workoutAdapter.submitList(viewState.workouts)
+
+                    rvSocialWorkouts.smoothScrollToPosition(workoutAdapter.itemCount - 1)
+                }
+                else {
+                    pbListLoading.visibility = View.VISIBLE
+                }
             }
         }.exhaustive
     }

--- a/app/src/main/java/hu/bme/aut/fitary/ui/socialWorkouts/SocialWorkoutsFragment.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/socialWorkouts/SocialWorkoutsFragment.kt
@@ -18,12 +18,6 @@ class SocialWorkoutsFragment :
     override fun provideViewModel() = getViewModelFromFactory()
     override fun getViewResource() = R.layout.fragment_workouts_social
 
-    override fun onDestroy() {
-        viewModel.cancelFlowCollection()
-
-        super.onDestroy()
-    }
-
     override fun render(viewState: SocialWorkoutsViewState) {
         when (viewState) {
             is Loading -> {

--- a/app/src/main/java/hu/bme/aut/fitary/ui/socialWorkouts/SocialWorkoutsFragment.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/socialWorkouts/SocialWorkoutsFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.View
 import androidx.recyclerview.widget.LinearLayoutManager
 import co.zsmb.rainbowcake.base.RainbowCakeFragment
-import co.zsmb.rainbowcake.base.ViewModelScope
 import co.zsmb.rainbowcake.dagger.getViewModelFromFactory
 import co.zsmb.rainbowcake.extensions.exhaustive
 import hu.bme.aut.fitary.R
@@ -16,8 +15,14 @@ class SocialWorkoutsFragment :
 
     private lateinit var workoutAdapter: WorkoutListAdapter
 
-    override fun provideViewModel() = getViewModelFromFactory(scope = ViewModelScope.Activity)
+    override fun provideViewModel() = getViewModelFromFactory()
     override fun getViewResource() = R.layout.fragment_workouts_social
+
+    override fun onDestroy() {
+        viewModel.cancelFlowCollection()
+
+        super.onDestroy()
+    }
 
     override fun render(viewState: SocialWorkoutsViewState) {
         when (viewState) {

--- a/app/src/main/java/hu/bme/aut/fitary/ui/socialWorkouts/SocialWorkoutsPresenter.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/socialWorkouts/SocialWorkoutsPresenter.kt
@@ -5,7 +5,6 @@ import hu.bme.aut.fitary.interactor.WorkoutInteractor
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -17,9 +16,9 @@ class SocialWorkoutsPresenter @Inject constructor(
     val workoutsChannel = Channel<MutableList<Workout>>()
 
     init {
-        CoroutineScope(Dispatchers.IO).launch {
+        workoutInteractor.allWorkoutsLiveData.observeForever { consumedWorkouts ->
 
-            workoutInteractor.workoutListChannel.consumeEach { consumedWorkouts ->
+            CoroutineScope(Dispatchers.IO).launch {
 
                 val workouts = consumedWorkouts.map { domainWorkout ->
                     Workout(

--- a/app/src/main/java/hu/bme/aut/fitary/ui/socialWorkouts/SocialWorkoutsPresenter.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/socialWorkouts/SocialWorkoutsPresenter.kt
@@ -2,12 +2,8 @@ package hu.bme.aut.fitary.ui.socialWorkouts
 
 import hu.bme.aut.fitary.interactor.UserInteractor
 import hu.bme.aut.fitary.interactor.WorkoutInteractor
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class SocialWorkoutsPresenter @Inject constructor(
@@ -15,7 +11,7 @@ class SocialWorkoutsPresenter @Inject constructor(
     private val userInteractor: UserInteractor
 ) {
 
-    val workoutsFlow: Flow<List<Workout>> = workoutInteractor.allWorkoutsFlow.map {
+    val workouts: Flow<List<Workout>> = workoutInteractor.allWorkoutsFlow.map {
         it.map { domainWorkout ->
             Workout(
                 username = userInteractor.getUsernameById(domainWorkout.uid) ?: "-",

--- a/app/src/main/java/hu/bme/aut/fitary/ui/socialWorkouts/SocialWorkoutsPresenter.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/socialWorkouts/SocialWorkoutsPresenter.kt
@@ -5,6 +5,8 @@ import hu.bme.aut.fitary.interactor.WorkoutInteractor
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -13,23 +15,13 @@ class SocialWorkoutsPresenter @Inject constructor(
     private val userInteractor: UserInteractor
 ) {
 
-    val workoutsChannel = Channel<MutableList<Workout>>()
-
-    init {
-        workoutInteractor.allWorkoutsLiveData.observeForever { consumedWorkouts ->
-
-            CoroutineScope(Dispatchers.IO).launch {
-
-                val workouts = consumedWorkouts.map { domainWorkout ->
-                    Workout(
-                        username = userInteractor.getUsernameById(domainWorkout.uid) ?: "-",
-                        score = domainWorkout.score,
-                        comment = domainWorkout.comment ?: "-"
-                    )
-                }.toMutableList()
-
-                workoutsChannel.send(workouts)
-            }
+    val workoutsFlow: Flow<List<Workout>> = workoutInteractor.allWorkoutsFlow.map {
+        it.map { domainWorkout ->
+            Workout(
+                username = userInteractor.getUsernameById(domainWorkout.uid) ?: "-",
+                score = domainWorkout.score,
+                comment = domainWorkout.comment ?: "-"
+            )
         }
     }
 

--- a/app/src/main/java/hu/bme/aut/fitary/ui/socialWorkouts/SocialWorkoutsViewModel.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/socialWorkouts/SocialWorkoutsViewModel.kt
@@ -1,18 +1,18 @@
 package hu.bme.aut.fitary.ui.socialWorkouts
 
 import co.zsmb.rainbowcake.base.RainbowCakeViewModel
-import kotlinx.coroutines.channels.consumeEach
+import kotlinx.coroutines.flow.collect
 import javax.inject.Inject
 
 class SocialWorkoutsViewModel @Inject constructor(
     private val socialWorkoutsPresenter: SocialWorkoutsPresenter
 ) : RainbowCakeViewModel<SocialWorkoutsViewState>(Loading) {
 
-    fun loadWorkouts() = execute {
-        viewState = Loading
-
-        socialWorkoutsPresenter.workoutsChannel.consumeEach {
-            viewState = SocialWorkoutsLoaded(it)
+    init {
+        executeNonBlocking {
+            socialWorkoutsPresenter.workoutsFlow.collect {
+                viewState = SocialWorkoutsLoaded(it)
+            }
         }
     }
 

--- a/app/src/main/java/hu/bme/aut/fitary/ui/socialWorkouts/SocialWorkoutsViewModel.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/socialWorkouts/SocialWorkoutsViewModel.kt
@@ -1,7 +1,6 @@
 package hu.bme.aut.fitary.ui.socialWorkouts
 
 import co.zsmb.rainbowcake.base.RainbowCakeViewModel
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collect
 import javax.inject.Inject
 
@@ -9,14 +8,12 @@ class SocialWorkoutsViewModel @Inject constructor(
     private val presenter: SocialWorkoutsPresenter
 ) : RainbowCakeViewModel<SocialWorkoutsViewState>(Loading) {
 
-    private val flowCollection: Job = executeCancellable(blocking = false) {
-        presenter.workouts.collect {
-            viewState = SocialWorkoutsLoaded(it)
+    init {
+        executeNonBlocking {
+            presenter.workouts.collect {
+                viewState = SocialWorkoutsLoaded(it)
+            }
         }
-    }
-
-    fun cancelFlowCollection() {
-        flowCollection.cancel()
     }
 
 }

--- a/app/src/main/java/hu/bme/aut/fitary/ui/socialWorkouts/SocialWorkoutsViewModel.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/socialWorkouts/SocialWorkoutsViewModel.kt
@@ -5,12 +5,12 @@ import kotlinx.coroutines.flow.collect
 import javax.inject.Inject
 
 class SocialWorkoutsViewModel @Inject constructor(
-    private val socialWorkoutsPresenter: SocialWorkoutsPresenter
+    private val presenter: SocialWorkoutsPresenter
 ) : RainbowCakeViewModel<SocialWorkoutsViewState>(Loading) {
 
     init {
         executeNonBlocking {
-            socialWorkoutsPresenter.workoutsFlow.collect {
+            presenter.workouts.collect {
                 viewState = SocialWorkoutsLoaded(it)
             }
         }

--- a/app/src/main/java/hu/bme/aut/fitary/ui/socialWorkouts/SocialWorkoutsViewModel.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/socialWorkouts/SocialWorkoutsViewModel.kt
@@ -1,6 +1,7 @@
 package hu.bme.aut.fitary.ui.socialWorkouts
 
 import co.zsmb.rainbowcake.base.RainbowCakeViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collect
 import javax.inject.Inject
 
@@ -8,12 +9,14 @@ class SocialWorkoutsViewModel @Inject constructor(
     private val presenter: SocialWorkoutsPresenter
 ) : RainbowCakeViewModel<SocialWorkoutsViewState>(Loading) {
 
-    init {
-        executeNonBlocking {
-            presenter.workouts.collect {
-                viewState = SocialWorkoutsLoaded(it)
-            }
+    private val flowCollection: Job = executeCancellable(blocking = false) {
+        presenter.workouts.collect {
+            viewState = SocialWorkoutsLoaded(it)
         }
+    }
+
+    fun cancelFlowCollection() {
+        flowCollection.cancel()
     }
 
 }

--- a/app/src/main/java/hu/bme/aut/fitary/ui/userWorkouts/UserWorkoutsFragment.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/userWorkouts/UserWorkoutsFragment.kt
@@ -18,12 +18,6 @@ class UserWorkoutsFragment :
     override fun provideViewModel() = getViewModelFromFactory()
     override fun getViewResource() = R.layout.fragment_workouts_user
 
-    override fun onDestroy() {
-        viewModel.cancelFlowCollection()
-
-        super.onDestroy()
-    }
-
     override fun render(viewState: UserWorkoutsViewState) {
         when (viewState) {
             is Loading -> {

--- a/app/src/main/java/hu/bme/aut/fitary/ui/userWorkouts/UserWorkoutsFragment.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/userWorkouts/UserWorkoutsFragment.kt
@@ -29,7 +29,10 @@ class UserWorkoutsFragment :
                 //pbListLoading.visibility = View.GONE
 
                 workoutAdapter.submitList(viewState.workouts)
-                rvUserWorkouts.smoothScrollToPosition(workoutAdapter.itemCount - 1)
+
+                if (workoutAdapter.itemCount > 0)
+                    rvUserWorkouts.smoothScrollToPosition(workoutAdapter.itemCount - 1)
+                return
             }
         }.exhaustive
     }

--- a/app/src/main/java/hu/bme/aut/fitary/ui/userWorkouts/UserWorkoutsFragment.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/userWorkouts/UserWorkoutsFragment.kt
@@ -20,12 +20,6 @@ class UserWorkoutsFragment :
     override fun provideViewModel() = getViewModelFromFactory(scope = ViewModelScope.Activity)
     override fun getViewResource() = R.layout.fragment_workouts_user
 
-    override fun onStart() {
-        super.onStart()
-
-        viewModel.loadWorkouts()
-    }
-
     override fun render(viewState: UserWorkoutsViewState) {
         when (viewState) {
             is Loading -> {

--- a/app/src/main/java/hu/bme/aut/fitary/ui/userWorkouts/UserWorkoutsFragment.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/userWorkouts/UserWorkoutsFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.View
 import androidx.recyclerview.widget.LinearLayoutManager
 import co.zsmb.rainbowcake.base.RainbowCakeFragment
-import co.zsmb.rainbowcake.base.ViewModelScope
 import co.zsmb.rainbowcake.dagger.getViewModelFromFactory
 import co.zsmb.rainbowcake.extensions.exhaustive
 import hu.bme.aut.fitary.R
@@ -16,9 +15,14 @@ class UserWorkoutsFragment :
 
     private lateinit var workoutAdapter: WorkoutListAdapter
 
-    // VM Scope in bound to MainActivity to keep VM when this Fragment is destroyed
-    override fun provideViewModel() = getViewModelFromFactory(scope = ViewModelScope.Activity)
+    override fun provideViewModel() = getViewModelFromFactory()
     override fun getViewResource() = R.layout.fragment_workouts_user
+
+    override fun onDestroy() {
+        viewModel.cancelFlowCollection()
+
+        super.onDestroy()
+    }
 
     override fun render(viewState: UserWorkoutsViewState) {
         when (viewState) {

--- a/app/src/main/java/hu/bme/aut/fitary/ui/userWorkouts/UserWorkoutsPresenter.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/userWorkouts/UserWorkoutsPresenter.kt
@@ -4,12 +4,23 @@ import hu.bme.aut.fitary.interactor.WorkoutInteractor
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class UserWorkoutsPresenter @Inject constructor(
     private val workoutInteractor: WorkoutInteractor,
 ) {
+
+    val workouts: Flow<List<Workout>> = workoutInteractor.userWorkoutsFlow.map {
+        it.map { domainWorkout ->
+            Workout(
+                score = domainWorkout.score,
+                comment = domainWorkout.comment ?: "-"
+            )
+        }
+    }
 
     val workoutsChannel = Channel<MutableList<Workout>>()
 

--- a/app/src/main/java/hu/bme/aut/fitary/ui/userWorkouts/UserWorkoutsPresenter.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/userWorkouts/UserWorkoutsPresenter.kt
@@ -1,35 +1,25 @@
 package hu.bme.aut.fitary.ui.userWorkouts
 
-import hu.bme.aut.fitary.domainModel.DomainWorkout
-import hu.bme.aut.fitary.interactor.Observer
+import androidx.lifecycle.MutableLiveData
 import hu.bme.aut.fitary.interactor.WorkoutInteractor
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class UserWorkoutsPresenter @Inject constructor(
     private val workoutInteractor: WorkoutInteractor,
-) : Observer<MutableList<DomainWorkout>> {
+) {
 
-    val workoutsChannel = Channel<MutableList<Workout>>()
+    val workoutsLiveData = MutableLiveData<MutableList<Workout>>()
 
     init {
-        workoutInteractor.addObserver(this)
-    }
-
-    override fun notify(newValue: MutableList<DomainWorkout>) {
-        CoroutineScope(Dispatchers.IO).launch {
-
-            val workouts = newValue.map { domainWorkout ->
-                    Workout(
-                        score = domainWorkout.score,
-                        comment = domainWorkout.comment ?: "-"
-                    )
+        workoutInteractor.userWorkoutsLiveData.observeForever {
+            val workouts = it.map { domainWorkout ->
+                Workout(
+                    score = domainWorkout.score,
+                    comment = domainWorkout.comment ?: "-"
+                )
             }.toMutableList()
 
-            workoutsChannel.send(workouts)
+            workoutsLiveData.value = workouts
         }
     }
 

--- a/app/src/main/java/hu/bme/aut/fitary/ui/userWorkouts/UserWorkoutsPresenter.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/userWorkouts/UserWorkoutsPresenter.kt
@@ -1,12 +1,8 @@
 package hu.bme.aut.fitary.ui.userWorkouts
 
 import hu.bme.aut.fitary.interactor.WorkoutInteractor
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class UserWorkoutsPresenter @Inject constructor(
@@ -19,25 +15,6 @@ class UserWorkoutsPresenter @Inject constructor(
                 score = domainWorkout.score,
                 comment = domainWorkout.comment ?: "-"
             )
-        }
-    }
-
-    val workoutsChannel = Channel<MutableList<Workout>>()
-
-    init {
-        workoutInteractor.userWorkoutsLiveData.observeForever {
-
-            CoroutineScope(Dispatchers.IO).launch {
-
-                val workouts = it.map { domainWorkout ->
-                    Workout(
-                        score = domainWorkout.score,
-                        comment = domainWorkout.comment ?: "-"
-                    )
-                }.toMutableList()
-
-                workoutsChannel.send(workouts)
-            }
         }
     }
 

--- a/app/src/main/java/hu/bme/aut/fitary/ui/userWorkouts/UserWorkoutsPresenter.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/userWorkouts/UserWorkoutsPresenter.kt
@@ -1,25 +1,32 @@
 package hu.bme.aut.fitary.ui.userWorkouts
 
-import androidx.lifecycle.MutableLiveData
 import hu.bme.aut.fitary.interactor.WorkoutInteractor
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class UserWorkoutsPresenter @Inject constructor(
     private val workoutInteractor: WorkoutInteractor,
 ) {
 
-    val workoutsLiveData = MutableLiveData<MutableList<Workout>>()
+    val workoutsChannel = Channel<MutableList<Workout>>()
 
     init {
         workoutInteractor.userWorkoutsLiveData.observeForever {
-            val workouts = it.map { domainWorkout ->
-                Workout(
-                    score = domainWorkout.score,
-                    comment = domainWorkout.comment ?: "-"
-                )
-            }.toMutableList()
 
-            workoutsLiveData.value = workouts
+            CoroutineScope(Dispatchers.IO).launch {
+
+                val workouts = it.map { domainWorkout ->
+                    Workout(
+                        score = domainWorkout.score,
+                        comment = domainWorkout.comment ?: "-"
+                    )
+                }.toMutableList()
+
+                workoutsChannel.send(workouts)
+            }
         }
     }
 

--- a/app/src/main/java/hu/bme/aut/fitary/ui/userWorkouts/UserWorkoutsViewModel.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/userWorkouts/UserWorkoutsViewModel.kt
@@ -1,18 +1,16 @@
 package hu.bme.aut.fitary.ui.userWorkouts
 
 import co.zsmb.rainbowcake.base.RainbowCakeViewModel
-import kotlinx.coroutines.channels.consumeEach
+import kotlinx.coroutines.flow.collect
 import javax.inject.Inject
 
 class UserWorkoutsViewModel @Inject constructor(
     private val userWorkoutsPresenter: UserWorkoutsPresenter
 ) : RainbowCakeViewModel<UserWorkoutsViewState>(Loading) {
 
-    init { // TODO Use load function or init?
-        executeNonBlocking { // TODO execute or executeNonBlocking?
-            viewState = Loading
-
-            userWorkoutsPresenter.workoutsChannel.consumeEach {
+    init {
+        executeNonBlocking {
+            userWorkoutsPresenter.workouts.collect {
                 viewState = UserWorkoutsLoaded(it)
             }
         }

--- a/app/src/main/java/hu/bme/aut/fitary/ui/userWorkouts/UserWorkoutsViewModel.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/userWorkouts/UserWorkoutsViewModel.kt
@@ -1,18 +1,14 @@
 package hu.bme.aut.fitary.ui.userWorkouts
 
 import co.zsmb.rainbowcake.base.RainbowCakeViewModel
-import kotlinx.coroutines.channels.consumeEach
-
 import javax.inject.Inject
 
 class UserWorkoutsViewModel @Inject constructor(
     private val userWorkoutsPresenter: UserWorkoutsPresenter
 ) : RainbowCakeViewModel<UserWorkoutsViewState>(Loading) {
 
-    fun loadWorkouts() = execute {
-        viewState = Loading
-
-        userWorkoutsPresenter.workoutsChannel.consumeEach {
+    init {
+        userWorkoutsPresenter.workoutsLiveData.observeForever {
             viewState = UserWorkoutsLoaded(it)
         }
     }

--- a/app/src/main/java/hu/bme/aut/fitary/ui/userWorkouts/UserWorkoutsViewModel.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/userWorkouts/UserWorkoutsViewModel.kt
@@ -1,6 +1,7 @@
 package hu.bme.aut.fitary.ui.userWorkouts
 
 import co.zsmb.rainbowcake.base.RainbowCakeViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collect
 import javax.inject.Inject
 
@@ -8,12 +9,13 @@ class UserWorkoutsViewModel @Inject constructor(
     private val presenter: UserWorkoutsPresenter
 ) : RainbowCakeViewModel<UserWorkoutsViewState>(Loading) {
 
-    init {
-        executeNonBlocking {
-            presenter.workouts.collect {
-                viewState = UserWorkoutsLoaded(it)
-            }
+    private val flowCollection: Job = executeCancellable(blocking = false) {
+        presenter.workouts.collect {
+            viewState = UserWorkoutsLoaded(it)
         }
     }
 
+    fun cancelFlowCollection() {
+        flowCollection.cancel()
+    }
 }

--- a/app/src/main/java/hu/bme/aut/fitary/ui/userWorkouts/UserWorkoutsViewModel.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/userWorkouts/UserWorkoutsViewModel.kt
@@ -1,7 +1,6 @@
 package hu.bme.aut.fitary.ui.userWorkouts
 
 import co.zsmb.rainbowcake.base.RainbowCakeViewModel
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collect
 import javax.inject.Inject
 
@@ -9,13 +8,12 @@ class UserWorkoutsViewModel @Inject constructor(
     private val presenter: UserWorkoutsPresenter
 ) : RainbowCakeViewModel<UserWorkoutsViewState>(Loading) {
 
-    private val flowCollection: Job = executeCancellable(blocking = false) {
-        presenter.workouts.collect {
-            viewState = UserWorkoutsLoaded(it)
+    init {
+        executeNonBlocking {
+            presenter.workouts.collect {
+                viewState = UserWorkoutsLoaded(it)
+            }
         }
     }
 
-    fun cancelFlowCollection() {
-        flowCollection.cancel()
-    }
 }

--- a/app/src/main/java/hu/bme/aut/fitary/ui/userWorkouts/UserWorkoutsViewModel.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/userWorkouts/UserWorkoutsViewModel.kt
@@ -1,15 +1,20 @@
 package hu.bme.aut.fitary.ui.userWorkouts
 
 import co.zsmb.rainbowcake.base.RainbowCakeViewModel
+import kotlinx.coroutines.channels.consumeEach
 import javax.inject.Inject
 
 class UserWorkoutsViewModel @Inject constructor(
     private val userWorkoutsPresenter: UserWorkoutsPresenter
 ) : RainbowCakeViewModel<UserWorkoutsViewState>(Loading) {
 
-    init {
-        userWorkoutsPresenter.workoutsLiveData.observeForever {
-            viewState = UserWorkoutsLoaded(it)
+    init { // TODO Use load function or init?
+        executeNonBlocking { // TODO execute or executeNonBlocking?
+            viewState = Loading
+
+            userWorkoutsPresenter.workoutsChannel.consumeEach {
+                viewState = UserWorkoutsLoaded(it)
+            }
         }
     }
 

--- a/app/src/main/java/hu/bme/aut/fitary/ui/userWorkouts/UserWorkoutsViewModel.kt
+++ b/app/src/main/java/hu/bme/aut/fitary/ui/userWorkouts/UserWorkoutsViewModel.kt
@@ -5,12 +5,12 @@ import kotlinx.coroutines.flow.collect
 import javax.inject.Inject
 
 class UserWorkoutsViewModel @Inject constructor(
-    private val userWorkoutsPresenter: UserWorkoutsPresenter
+    private val presenter: UserWorkoutsPresenter
 ) : RainbowCakeViewModel<UserWorkoutsViewState>(Loading) {
 
     init {
         executeNonBlocking {
-            userWorkoutsPresenter.workouts.collect {
+            presenter.workouts.collect {
                 viewState = UserWorkoutsLoaded(it)
             }
         }


### PR DESCRIPTION
Removed Channels and LiveDatas from being the connecting mechanisms of layers and replaced them with Flows.
Workout views' ViewModels aren't bound to the main Activity's scope anymore, meaning VMs and Presenters also get destroyed on Fragment destruction and recreated every time the view is opened again. 
StateFlows make sure, that the new instances get the latest database state on "subscription" to the data flow collection.