### PR TITLE
GitHub Actions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,0 +1,17 @@
+name: GitHub Actions Demo
+on: [push]
+jobs:
+  Explore-GitHub-Actions:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
+      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
+      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
+      - name: List files in the repository
+        run: |
+          ls ${{ github.workspace }}
+      - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -35,12 +35,15 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Build with Gradle and sign app bundle
+      - name: Build, align and sign app with Gradle
         run: ./gradlew app:assembleRelease
         env:
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+
+      - name: Check if APK is optimized with zipalign
+        run: zipalign -c -v 4 app/build/outputs/apk/release/app-release.apk
 
       - name: Upload signed APK
         uses: actions/upload-artifact@v2

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -44,10 +44,13 @@ jobs:
           keyPassword: ${{ secrets.KEY_PASSWORD }}
 
       - name: Print signedReleaseFile
-        run: echo ${{steps.signArtifact.outputs.signedReleaseFile}}
+        run: echo "signedReleaseFile's value is ${{steps.signArtifact.outputs.signedReleaseFile}}."
+
+      - name: Print file system tree
+        run: tree
 
       - name: Upload apk
         uses: actions/upload-artifact@v2
         with:
-          name: release.apk
+          name: release-artifact
           path: app/build/outputs/apk/release

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -28,7 +28,7 @@ jobs:
         run: echo $FIREBASE_CONFIG > app/google-services.json
 
       - name: Decode Keystore
-        run: echo ${{ secrets.KEYSTORE }} | base64 -di > app/fitary_keystore.jks
+        run: echo "${{ secrets.KEYSTORE }}" | base64 -di > app/fitary_keystore.jks
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,22 +1,26 @@
-name: GitHub Actions Demo
-on: 
+name: Android CI
+
+on:
   push:
   pull_request:
     branches:
       - main
       - dev
+
 jobs:
-  Explore-GitHub-Actions:
+  build:
     runs-on: ubuntu-latest
+
     steps:
-      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
-      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
-      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
-      - name: Check out repository code
-        uses: actions/checkout@v2
-      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
-      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
-      - name: List files in the repository
-        run: |
-          ls ${{ github.workspace }}
-      - run: echo "🍏 This job's status is ${{ job.status }}."
+      - uses: actions/checkout@v2
+      - name: set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: "11"
+          distribution: "adopt"
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Build with Gradle
+        run: ./gradlew build

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,4 +1,4 @@
-name: Android CI
+name: Build
 
 on:
   push:
@@ -8,17 +8,17 @@ on:
       - dev
 
 jobs:
-  build:
+  Build:
     runs-on: ubuntu-latest
 
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Set up JDK 11
+      - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          java-version: "11"
+          java-version: "8"
           distribution: "adopt"
           cache: gradle
 

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -37,7 +37,7 @@ jobs:
         id: signArtifact
         uses: r0adkll/sign-android-release@v1.0.1
         with:
-          releaseDirectory: app/build/outputs/apk/ourbuildtype/release
+          releaseDirectory: app/build/outputs/apk/debug
           alias: ${{ secrets.KEY_ALIAS }}
           signingKeyBase64: ${{ secrets.KEYSTORE }}
           keyStorePassword: ${{ secrets.KEYSTORE_PASSWORD }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -33,7 +33,15 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew assembleDebug
 
-      # TODO Sign apk
+      - name: Sign artifact
+        id: signArtifact
+        uses: r0adkll/sign-android-release@v1.0.1
+        with:
+          releaseDirectory: app/build/outputs/apk/ourbuildtype/release
+          alias: ${{ secrets.KEY_ALIAS }}
+          signingKeyBase64: ${{ secrets.KEYSTORE }}
+          keyStorePassword: ${{ secrets.KEYSTORE_PASSWORD }}
+          keyPassword: ${{ secrets.KEY_PASSWORD }}
 
       - name: Upload apk
         uses: actions/upload-artifact@v2

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -32,3 +32,11 @@ jobs:
 
       - name: Build with Gradle
         run: ./gradlew build
+
+      # TODO Sign apk
+
+      - name: Upload apk
+        uses: actions/upload-artifact@v2
+        with:
+          name: fitary-debug.apk
+          path: app/build/outputs/apk/debug/

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -28,24 +28,19 @@ jobs:
         run: echo $FIREBASE_CONFIG > app/google-services.json
 
       - name: Decode Keystore
-        env:
-            ENCODED_KEYSTORE: ${{ secrets.KEYSTORE }}
-        run: |
-            TMP_KEYSTORE_FILE_PATH="${RUNNER_TEMP}"/keystore
-            mkdir "${TMP_KEYSTORE_FILE_PATH}"
-            echo $ENCODED_KEYSTORE | base64 -di > "${TMP_KEYSTORE_FILE_PATH}"/fitary_keystore.jks
+        run: echo ${{ secrets.KEYSTORE }} | base64 -di > app/fitary_keystore.jks
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
       - name: Build with Gradle and sign app bundle
-        run: ./gradlew app:bundleRelease
+        run: ./gradlew app:assembleRelease
         env:
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
 
-      - name: Upload apk
+      - name: Upload build artifacts
         uses: actions/upload-artifact@v2
         with:
           name: Build Artifacts

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -31,13 +31,13 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build with Gradle
-        run: ./gradlew assembleDebug
+        run: ./gradlew assembleRelease
 
       - name: Sign artifact
         id: signArtifact
         uses: r0adkll/sign-android-release@v1.0.1
         with:
-          releaseDirectory: app/build/outputs/apk/debug
+          releaseDirectory: app/build/outputs/apk/release
           alias: ${{ secrets.KEY_ALIAS }}
           signingKeyBase64: ${{ secrets.KEYSTORE }}
           keyStorePassword: ${{ secrets.KEYSTORE_PASSWORD }}
@@ -46,5 +46,5 @@ jobs:
       - name: Upload apk
         uses: actions/upload-artifact@v2
         with:
-          name: debug apk
-          path: app/build/outputs/apk/debug/app-debug.apk
+          name: release.apk
+          path: ${{steps.signArtifact.outputs.signedReleaseFile}}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -27,30 +27,26 @@ jobs:
           FIREBASE_CONFIG: ${{ secrets.FIREBASE_CONFIG }}
         run: echo $FIREBASE_CONFIG > app/google-services.json
 
+      - name: Decode Keystore
+        env:
+            ENCODED_KEYSTORE: ${{ secrets.KEYSTORE }}
+        run: |
+            TMP_KEYSTORE_FILE_PATH="${RUNNER_TEMP}"/keystore
+            mkdir "${TMP_KEYSTORE_FILE_PATH}"
+            echo $ENCODED_KEYSTORE | base64 -di > "${TMP_KEYSTORE_FILE_PATH}"/fitary_keystore.jks
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Build with Gradle
-        run: ./gradlew assembleRelease
-
-      - name: Sign artifact
-        id: signArtifact
-        uses: r0adkll/sign-android-release@v1.0.1
-        with:
-          releaseDirectory: app/build/outputs/apk/release
-          alias: ${{ secrets.KEY_ALIAS }}
-          signingKeyBase64: ${{ secrets.KEYSTORE }}
-          keyStorePassword: ${{ secrets.KEYSTORE_PASSWORD }}
-          keyPassword: ${{ secrets.KEY_PASSWORD }}
-
-      - name: Print signedReleaseFile
-        run: echo "signedReleaseFile's value is ${{steps.signArtifact.outputs.signedReleaseFile}}."
-
-      - name: Print file system tree
-        run: tree
+      - name: Build with Gradle and sign app bundle
+        run: ./gradlew app:bundleRelease
+        env:
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
 
       - name: Upload apk
         uses: actions/upload-artifact@v2
         with:
-          name: release-artifact
-          path: app/build/outputs/apk/release
+          name: Build Artifacts
+          path: app/build/outputs/

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,5 +1,10 @@
 name: GitHub Actions Demo
-on: [push]
+on: 
+  push:
+  pull_request:
+    branches:
+      - main
+      - dev
 jobs:
   Explore-GitHub-Actions:
     runs-on: ubuntu-latest

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -12,15 +12,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - name: set up JDK 11
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
           java-version: "11"
           distribution: "adopt"
           cache: gradle
 
+      - name: Decode google-services.json
+        env:
+          FIREBASE_CONFIG: ${{ secrets.FIREBASE_CONFIG }}
+        run: echo $FIREBASE_CONFIG > app/google-services.json
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
+
       - name: Build with Gradle
         run: ./gradlew build

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -31,12 +31,12 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build with Gradle
-        run: ./gradlew build
+        run: ./gradlew assembleDebug
 
       # TODO Sign apk
 
       - name: Upload apk
         uses: actions/upload-artifact@v2
         with:
-          name: fitary-debug.apk
-          path: app/build/outputs/apk/debug/
+          name: debug apk
+          path: app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -43,8 +43,11 @@ jobs:
           keyStorePassword: ${{ secrets.KEYSTORE_PASSWORD }}
           keyPassword: ${{ secrets.KEY_PASSWORD }}
 
+      - name: Print signedReleaseFile
+        run: echo ${{steps.signArtifact.outputs.signedReleaseFile}}
+
       - name: Upload apk
         uses: actions/upload-artifact@v2
         with:
           name: release.apk
-          path: ${{steps.signArtifact.outputs.signedReleaseFile}}
+          path: app/build/outputs/apk/release

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -28,7 +28,9 @@ jobs:
         run: echo $FIREBASE_CONFIG > app/google-services.json
 
       - name: Decode Keystore
-        run: echo "${{ secrets.KEYSTORE }}" | base64 -di > app/fitary_keystore.jks
+        env: 
+          ENCODED_KEYSTORE: ${{ secrets.KEYSTORE }}
+        run: echo $ENCODED_KEYSTORE | base64 -di > app/fitary_keystore.jks
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
@@ -40,8 +42,8 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
 
-      - name: Upload build artifacts
+      - name: Upload signed APK
         uses: actions/upload-artifact@v2
         with:
           name: Build Artifacts
-          path: app/build/outputs/
+          path: app/build/outputs/apk/release/app-release.apk

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Build
+
+on: push
+
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: "8"
+          distribution: "adopt"
+          cache: gradle
+
+      - name: Decode google-services.json
+        env:
+          FIREBASE_CONFIG: ${{ secrets.FIREBASE_CONFIG }}
+        run: echo $FIREBASE_CONFIG > app/google-services.json
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew app:build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,4 +26,4 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build with Gradle
-        run: ./gradlew app:build
+        run: ./gradlew app:assembleDebug

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
-name: Build
+name: Release
 
 on:
-  push:
   pull_request:
     branches:
       - main
@@ -41,9 +40,6 @@ jobs:
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
-
-      - name: Check if APK is optimized with zipalign
-        run: zipalign -c -v 4 app/build/outputs/apk/release/app-release.apk
 
       - name: Upload signed APK
         uses: actions/upload-artifact@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
       - dev
 
 jobs:
-  Build:
+  Assemble-Release:
     runs-on: ubuntu-latest
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,5 @@ fabric.properties
 !/gradle/wrapper/gradle-wrapper.jar
 
 # End of https://www.toptal.com/developers/gitignore/api/androidstudio,firebase
+
+.vscode/settings.json

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,6 +29,7 @@ android {
     buildTypes {
         release {
             signingConfig signingConfigs.release
+            zipAlignEnabled true
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,8 +18,17 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    signingConfigs {
+        release {
+            storeFile file('fitary_keystore.jks')
+            storePassword System.getenv('KEYSTORE_PASSWORD')
+            keyAlias System.getenv('KEY_ALIAS')
+            keyPassword System.getenv('KEY_PASSWORD')
+        }
+    }
     buildTypes {
         release {
+            signingConfig signingConfigs.release
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
@@ -30,22 +39,6 @@ android {
     }
     kotlinOptions {
         jvmTarget = '1.8'
-    }
-    signingConfigs {
-        release {
-            def tmpFilePath = System.getProperty('user.home') + '/work/_temp/keystore/'
-            def allFilesFromDir = new File(tmpFilePath).listFiles()
-
-            if (allFilesFromDir != null) {
-                def keystoreFile = allFilesFromDir.first()
-                keystoreFile.renameTo('keystore/fitary_keystore.jks')
-            }
-
-            storeFile = file('keystore/fitary_keystore.jks')
-            storePassword System.getenv('KEYSTORE_PASSWORD')
-            keyAlias System.getenv('KEY_ALIAS')
-            keyPassword System.getenv('KEY_PASSWORD')
-        }
     }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,6 +31,22 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+    signingConfigs {
+        release {
+            def tmpFilePath = System.getProperty('user.home') + '/work/_temp/keystore/'
+            def allFilesFromDir = new File(tmpFilePath).listFiles()
+
+            if (allFilesFromDir != null) {
+                def keystoreFile = allFilesFromDir.first()
+                keystoreFile.renameTo('keystore/fitary_keystore.jks')
+            }
+
+            storeFile = file('keystore/fitary_keystore.jks')
+            storePassword System.getenv('KEYSTORE_PASSWORD')
+            keyAlias System.getenv('KEY_ALIAS')
+            keyPassword System.getenv('KEY_PASSWORD')
+        }
+    }
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.4.31"
+    ext.kotlin_version = '1.4.31'
     repositories {
         google()
         jcenter()
@@ -10,8 +10,8 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.gms:google-services:4.3.5'
 
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
+    // NOTE: Do not place your application dependencies here; they belong
+    // in the individual module build.gradle files
     }
 }
 


### PR DESCRIPTION
**Added 2 GitHub Actions YML files for the following events**

## Pull-request
- Sets up Java 8
- Checks out the repository
- Creates google-services.json
- Decodes and creates a keystore file
- Puts signing properties in environment variables to be available during signing
- Runs the gradle tak: `app:assembleRelease`
  - Signs the generated APK
  - Runs `zipalign` for optimization
- Uploads the signed APK as the build artifact

## Push
Similar to the first one, but with less steps and different gradle task.
- Sets up Java 8
- Checks out the repository
- Creates google-services.json
- Runs the gradle task: `app:assembleDebug`

It was hard to decide which gradle task to run, because I found contradictory information on `assemble` and `build`.
The [gradle documentation here](https://docs.gradle.org/current/userguide/java_plugin.html#lifecycle_tasks) says `build` **depends on** `assemble`, but I found that not false.

I listed the subtasks of each task by running them with the `--dry-run` modifier and the results show that `assembleDebug` has actually more subtasks than `buildDebug`.

``` cmd
$ gradle :app:buildDebug --dry-run | wc -l
44
```

``` cmd
$ gradle :app:assembleDebug --dry-run | wc -l
47
```

Listing the tasks
``` cmd
$ gradle app:buildDebug --dry-run

> Configure project :app
Warning: The 'kotlin-android-extensions' Gradle plugin is deprecated. Please use this migration guide (https://goo.gle/kotlin-android-extensions-deprecation) to start working with View Binding (https://developer.android.com/topic/libraries/view-binding) and the 'kotlin-parcelize' plugin.
:app:preBuild SKIPPED
:app:preDebugBuild SKIPPED
:app:compileDebugRenderscript SKIPPED
:app:generateDebugResValues SKIPPED
:app:generateDebugResources SKIPPED
:app:processDebugGoogleServices SKIPPED
:app:mergeDebugResources SKIPPED
:app:createDebugCompatibleScreenManifests SKIPPED
:app:extractDeepLinksDebug SKIPPED
:app:processDebugMainManifest SKIPPED
:app:processDebugManifest SKIPPED
:app:processApplicationManifestDebugForBundle SKIPPED
:app:bundleDebugResources SKIPPED
:app:mergeDebugShaders SKIPPED
:app:compileDebugShaders SKIPPED
:app:generateDebugAssets SKIPPED
:app:mergeDebugAssets SKIPPED
:app:compileDebugAidl SKIPPED
:app:generateDebugBuildConfig SKIPPED
:app:checkDebugAarMetadata SKIPPED
:app:processDebugManifestForPackage SKIPPED
:app:processDebugResources SKIPPED
:app:kaptGenerateStubsDebugKotlin SKIPPED
:app:kaptDebugKotlin SKIPPED
:app:compileDebugKotlin SKIPPED
:app:processDebugJavaRes SKIPPED
:app:mergeDebugJavaResource SKIPPED
:app:checkDebugDuplicateClasses SKIPPED
:app:desugarDebugFileDependencies SKIPPED
:app:mergeExtDexDebug SKIPPED
:app:mergeLibDexDebug SKIPPED
:app:javaPreCompileDebug SKIPPED
:app:compileDebugJavaWithJavac SKIPPED
:app:dexBuilderDebug SKIPPED
:app:mergeProjectDexDebug SKIPPED
:app:mergeDebugJniLibFolders SKIPPED
:app:mergeDebugNativeLibs SKIPPED
:app:stripDebugDebugSymbols SKIPPED
:app:buildDebugPreBundle SKIPPED

BUILD SUCCESSFUL in 993ms
```

``` cmd
$ gradle :app:assembleDebug --dry-run

> Configure project :app
Warning: The 'kotlin-android-extensions' Gradle plugin is deprecated. Please use this migration guide (https://goo.gle/kotlin-android-extensions-deprecation) to start working with View Binding (https://developer.android.com/topic/libraries/view-binding) and the 'kotlin-parcelize' plugin.
:app:preBuild SKIPPED
:app:preDebugBuild SKIPPED
:app:compileDebugAidl SKIPPED
:app:compileDebugRenderscript SKIPPED
:app:generateDebugBuildConfig SKIPPED
:app:checkDebugAarMetadata SKIPPED
:app:generateDebugResValues SKIPPED
:app:generateDebugResources SKIPPED
:app:processDebugGoogleServices SKIPPED
:app:mergeDebugResources SKIPPED
:app:createDebugCompatibleScreenManifests SKIPPED
:app:extractDeepLinksDebug SKIPPED
:app:processDebugMainManifest SKIPPED
:app:processDebugManifest SKIPPED
:app:processDebugManifestForPackage SKIPPED
:app:processDebugResources SKIPPED
:app:kaptGenerateStubsDebugKotlin SKIPPED
:app:kaptDebugKotlin SKIPPED
:app:compileDebugKotlin SKIPPED
:app:javaPreCompileDebug SKIPPED
:app:compileDebugJavaWithJavac SKIPPED
:app:compileDebugSources SKIPPED
:app:mergeDebugNativeDebugMetadata SKIPPED
:app:mergeDebugShaders SKIPPED
:app:compileDebugShaders SKIPPED
:app:generateDebugAssets SKIPPED
:app:mergeDebugAssets SKIPPED
:app:compressDebugAssets SKIPPED
:app:processDebugJavaRes SKIPPED
:app:mergeDebugJavaResource SKIPPED
:app:checkDebugDuplicateClasses SKIPPED
:app:desugarDebugFileDependencies SKIPPED
:app:mergeExtDexDebug SKIPPED
:app:mergeLibDexDebug SKIPPED
:app:dexBuilderDebug SKIPPED
:app:mergeProjectDexDebug SKIPPED
:app:mergeDebugJniLibFolders SKIPPED
:app:mergeDebugNativeLibs SKIPPED
:app:stripDebugDebugSymbols SKIPPED
:app:validateSigningDebug SKIPPED
:app:packageDebug SKIPPED
:app:assembleDebug SKIPPED

BUILD SUCCESSFUL in 1s
```

### ProAndroidDev Article
https://proandroiddev.com/understanding-gradle-the-build-lifecycle-5118c1da613f
In this article I found a directed graph depicting the dependencies between gradle tasks and it indeed shows they are not dependent on each other.

Since I don't have any tests yet I decided to use `assembleDebug`, because in my project it has all the subtasks of `buildDebug` and even more.

![](https://miro.medium.com/max/700/1*E5JMRbW525OHTa1Op7dGGA.png)